### PR TITLE
GitHub actions set env test

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+env:
+  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+
 jobs:
   build:
 
@@ -14,15 +17,33 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Build with Gradle Wrapper
-      run: |
-        cd platform-back
-        chmod +x gradlew
-        ./gradlew build
+      - name: copy yml file
+        run: |
+          echo "${{ secrets.APPLICATION_YML }}" > ./platform-back/src/main/resources/application.yml
+
+      - name: Build with Gradle Wrapper
+        run: |
+          cd platform-back
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: docker build 가능하도록 환경 설정
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: docker hub에로그인
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
+
+      - name: docker image 빌드 및 푸시
+        run: |
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_IMAGE_NAME }} -f ./platform-back/Dockerfile .
+          docker push ${{ secrets.DOCKER_IMAGE_NAME }}

--- a/platform-back/Dockerfile
+++ b/platform-back/Dockerfile
@@ -1,22 +1,7 @@
-FROM amd64/amazoncorretto:17 AS BUILD
-
-WORKDIR /app
-
-COPY gradlew .
-RUN sed -i 's/\r$//' gradlew
-COPY gradle ./gradle
-COPY build.gradle .
-COPY settings.gradle .
-
-COPY src ./src
-
-RUN chmod +x ./gradlew
-RUN ./gradlew build -x test
-
 FROM amd64/amazoncorretto:17
 
 WORKDIR /app
 
-COPY --from=build /app/build/libs/platform-back-0.0.1-SNAPSHOT.jar /app/platform-back.jar
+COPY ./platform-back/build/libs/platform-back-0.0.1-SNAPSHOT.jar /app/platform-back.jar
 
 CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "platform-back.jar"]

--- a/platform-back/src/main/java/org/example/platformback/test/TestController.java
+++ b/platform-back/src/main/java/org/example/platformback/test/TestController.java
@@ -1,12 +1,23 @@
 package org.example.platformback.test;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class TestController {
+    @Value("${jwt.secret}")
+    private String secretKey;
+
     @GetMapping("/test")
     public String test() {
         return "platform server on";
+    }
+
+    @GetMapping("/secret")
+    public ResponseEntity<String> secret() {
+        System.out.println("secret key is " + secretKey);
+        return ResponseEntity.ok("secret key is " + secretKey);
     }
 }


### PR DESCRIPTION
### 배경

SSO로 인증 체계가 변경되면서 모든 팀의 JWT 시크릿 키가 통일되었습니다. 이로 인해 시크릿 키가 변경될 때마다 모든 팀이 yml 파일을 수정하고 배포해야 하는 문제가 발생했습니다.

이를 아래와 같이 해결하고자 합니다.

### 해결

모든 팀에서는 JWT 토큰을 사용하기 때문에 yml 파일 내부에 secret key를 설정하는 부분이 있을 것이고, 해당 부분을 **환경 변수로 처리함**으로써 문제를 해결하고자 합니다.

해당 환경 변수는 Organization Secrets에 설정하여 모든 팀이 동일한 환경 변수를 사용할 수 있도록 합니다.

CI/CD 워크플로우에서는 `env:`를 통해 Organization Secrets의 환경 변수를 설정하고, 이를 yml 파일에서 사용합니다. 

비록 시크릿 키가 수정될 때마다 모든 팀이 재배포를 해야 하지만, yml 파일을 수정하는 과정을 생략할 수 있어 수정이 더 편리해질 것으로 예상됩니다.

> **application.yml**
> 

```groovy
jwt:
  secret: ${JWT_SECRET_KEY}
```

> **Github Actions workflow**
> 

```groovy
...

env:
  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}

jobs:
  build:

...
```

### 검증

변경된 workflow를 거친 이미지를 도커에 push한 뒤, 로컬에서 pull 받아서 실행했습니다.

아래 API를 추가하여 secret key가 잘 들어갔는지 확인했습니다.

```groovy
@Value("${jwt.secret}")
private String secretKey;
    
@GetMapping("/secret")
public ResponseEntity<String> secret() {
	  System.out.println("secret key is " + secretKey);
	  return ResponseEntity.ok("secret key is " + secretKey);
}
```

> **사전 작업 : secrets 설정**
> 
- **secrets.APPLICATION_YML**
    
    ```yaml
    jwt:
      secret: ${JWT_SECRET_KEY}
    ```
    
- **secrets.JWT_SECRET_KEY**
    
    ```yaml
    GITHUB_ACTIONS_JWT_SECRET_KEY
    ```
    
- **workflow**
    
    ```yaml
    name: Java CI with Gradle
    
    on:
      push:
        branches: [ "develop" ]
      pull_request:
        branches: [ "develop" ]
    
    env:
      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
    
    jobs:
      build:
    
        runs-on: ubuntu-latest
        permissions:
          contents: read
    
        steps:
          - uses: actions/checkout@v4
          - name: Set up JDK 17
            uses: actions/setup-java@v4
            with:
              java-version: '17'
              distribution: 'temurin'
    
          - name: copy yml file
            run: |
              echo "${{ secrets.APPLICATION_YML }}" > ./platform-back/src/main/resources/application.yml
    
          - name: Build with Gradle Wrapper
            run: |
              cd platform-back
              chmod +x gradlew
              ./gradlew clean build -x test
    
          - name: docker build 가능하도록 환경 설정
            uses: docker/setup-buildx-action@v2.9.1
    
          - name: docker hub에로그인
            uses: docker/login-action@v2.2.0
            with:
              username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
              password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
    
          - name: docker image 빌드 및 푸시
            run: |
              docker build --platform linux/amd64 -t ${{ secrets.DOCKER_IMAGE_NAME }} -f ./platform-back/Dockerfile .
              docker push ${{ secrets.DOCKER_IMAGE_NAME }}
    
    ```
    

### 결과

workflow 이후 해당 image를 로컬에서 pull 받아서 실행한 결과 

아래와 같이 Github Actions Secret에 넣은 환경 변수가 잘 들어간 것을 볼 수 있습니다.

![image](https://github.com/KWY0218/Makers-Auth-PoC/assets/82709044/3f02f438-c633-4808-8c21-f615e1e54d4e)

![image](https://github.com/KWY0218/Makers-Auth-PoC/assets/82709044/4b4852bc-856f-402d-8c33-ace70bb31430)

